### PR TITLE
Enable PWA Support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,4 +5,12 @@ module.exports = {
     'eslint-comments/no-unlimited-disable': 0,
     'eslint-comments/no-unused-disable': 0,
   },
+  overrides: [
+    {
+      files: ['*.js'],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 0,
+      },
+    },
+  ],
 };

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+const CACHE = 'network-or-cache';
+
+// Open a cache and use `addAll()` with an array of assets to add all of them
+// to the cache. Return a promise resolving when all the assets are added.
+const precache = async () => {
+  const cache = await caches.open(CACHE);
+
+  await cache.addAll([
+    // ? Precached resources.
+  ]);
+};
+
+// Time limited network request. If the network fails or the response is not
+// served before timeout, the promise is rejected.
+const fromNetwork = async (request, timeout) => {
+  const timeoutId = setTimeout(() => {
+    throw new Error('Request timeout.');
+  }, timeout);
+
+  const response = await fetch(request);
+
+  clearTimeout(timeoutId);
+
+  return response;
+};
+
+// Open the cache where the assets were stored and search for the requested
+// resource. Notice that in case of no matching, the promise still resolves
+// but it does with `undefined` as value.
+const fromCache = async (request) => {
+  const cache = await caches.open(CACHE);
+  const matching = await cache.match(request);
+
+  if (matching === undefined) throw new Error('no-match');
+
+  return matching;
+};
+
+// On install, cache some resource.
+self.addEventListener('install', (evt) => {
+  console.log('The service worker is being installed.');
+
+  // Ask the service worker to keep installing until the returning promise
+  // resolves.
+  evt.waitUntil(precache());
+});
+
+// On fetch, use cache but update the entry with the latest contents
+// from the server.
+self.addEventListener('fetch', (evt) => {
+  console.log('The service worker is serving the asset.');
+
+  // Try network and if it fails, go for the cached copy.
+  evt.respondWith(
+    fromNetwork(evt.request, 4000).catch(() => fromCache(evt.request)),
+  );
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,9 +4,16 @@ import App from './App';
 
 AppRegistry.registerComponent('dooboo', () => App);
 
-if (Platform.OS === 'web')
+if (Platform.OS === 'web') {
   AppRegistry.runApplication('dooboo', {
     rootTag: document.getElementById('root'),
   });
+
+  // Register service worker.
+  if ('serviceWorker' in navigator)
+    navigator.serviceWorker.register(
+      `${process.env.PUBLIC_URL}/service-worker.js`,
+    );
+}
 
 export default App;


### PR DESCRIPTION
### Changes
- Add `public/service-worker.js`.
- Register service worker in `src/index.tsx`.

### Notes
- Web app manifest is already supported in CRA.
- Cannot use typescript inside service worker.

**This PR is made on top of https://github.com/dooboolab/dooboo-native-ts/pull/162**