### PR TITLE
[android] fix: initialize current locale on create activity

### DIFF
--- a/android/app/src/main/java/com/dooboo/MainActivity.java
+++ b/android/app/src/main/java/com/dooboo/MainActivity.java
@@ -1,6 +1,7 @@
 package com.dooboo;
 
 import android.content.res.Configuration;
+import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
@@ -29,6 +30,13 @@ public class MainActivity extends ReactActivity {
                 return new RNGestureHandlerEnabledRootView(MainActivity.this);
             }
         };
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        MainActivity.currentLocale = getResources().getConfiguration().locale.toString();
     }
 
     @Override


### PR DESCRIPTION
In the previous code, there was a problem with restarting the app after running the app on Android and rotating the screen. The reason was that the currentLocale value was not initialized when the app was launched.  In this pr, the currentLocale value to be initialized at the onCreate of MainActivity.

It referenced [ftb rn example](https://github.com/facebook/fbt/blame/rn-demo-app/android/app/src/main/java/com/fbtrndemoapp/MainActivity.java#L39)