### PR TITLE
Fix ios build error & support dooboo-ui with patch-packages

### DIFF
--- a/patches/dooboo-ui+0.1.25.patch
+++ b/patches/dooboo-ui+0.1.25.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/dooboo-ui/Icon/index.js b/node_modules/dooboo-ui/Icon/index.js
+index 34fb1f7..34c9d92 100644
+--- a/node_modules/dooboo-ui/Icon/index.js
++++ b/node_modules/dooboo-ui/Icon/index.js
+@@ -1,7 +1,7 @@
+ import collectingFontIconSelection from './selection.json';
+ import { createIconSetFromIcoMoon } from 'react-native-vector-icons';
+ import styled from '@emotion/native';
+-const Ico = createIconSetFromIcoMoon(collectingFontIconSelection, 'IcoMoon', 'doobooui.ttf');
++const Ico = createIconSetFromIcoMoon(collectingFontIconSelection);
+ export const Icon = styled(Ico) `
+   color: ${({ theme, color }) => color || theme.text};
+ `;

--- a/patches/react-native+0.65.1.patch
+++ b/patches/react-native+0.65.1.patch
@@ -1,0 +1,214 @@
+diff --git a/node_modules/react-native/scripts/.packager.env b/node_modules/react-native/scripts/.packager.env
+new file mode 100644
+index 0000000..361f5fb
+--- /dev/null
++++ b/node_modules/react-native/scripts/.packager.env
+@@ -0,0 +1 @@
++export RCT_METRO_PORT=8081
+diff --git a/node_modules/react-native/scripts/generate-specs.sh b/node_modules/react-native/scripts/generate-specs.sh
+index b66f4c9..f073fd9 100755
+--- a/node_modules/react-native/scripts/generate-specs.sh
++++ b/node_modules/react-native/scripts/generate-specs.sh
+@@ -1,101 +1,101 @@
+-#!/bin/bash
+-# Copyright (c) Facebook, Inc. and its affiliates.
+-#
+-# This source code is licensed under the MIT license found in the
+-# LICENSE file in the root directory of this source tree.
+-
+-# This script collects the JavaScript spec definitions for core
+-# native modules and components, then uses react-native-codegen
+-# to generate native code.
+-#
+-# Optionally, set these envvars to override defaults:
+-# - SRCS_DIR: Path to JavaScript sources
+-# - MODULES_LIBRARY_NAME: Defaults to FBReactNativeSpec
+-# - MODULES_OUTPUT_DIR: Defaults to React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME
+-# - COMPONENTS_LIBRARY_NAME: Defaults to rncore
+-# - COMPONENTS_OUTPUT_DIR: Defaults to ReactCommon/react/renderer/components/$COMPONENTS_LIBRARY_NAME
+-#
+-# Usage:
+-#   ./scripts/generate-specs.sh
+-#   SRCS_DIR=myapp/js MODULES_LIBRARY_NAME=MySpecs MODULES_OUTPUT_DIR=myapp/MySpecs ./scripts/generate-specs.sh
+-#
+-
+-# shellcheck disable=SC2038
+-
+-set -e
+-
+-THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
+-TEMP_DIR=$(mktemp -d /tmp/react-native-codegen-XXXXXXXX)
+-RN_DIR=$(cd "$THIS_DIR/.." && pwd)
+-USE_FABRIC="${USE_FABRIC:-0}"
+-
+-# Find path to Node
+-# shellcheck source=/dev/null
+-source "$RN_DIR/scripts/find-node.sh"
+-
+-NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
+-
+-cleanup () {
+-  set +e
+-  rm -rf "$TEMP_DIR"
+-  set -e
+-}
+-
+-describe () {
+-  printf "\\n\\n>>>>> %s\\n\\n\\n" "$1"
+-}
+-
+-main() {
+-  SRCS_DIR=${SRCS_DIR:-$(cd "$RN_DIR/Libraries" && pwd)}
+-  MODULES_LIBRARY_NAME=${MODULES_LIBRARY_NAME:-FBReactNativeSpec}
+-
+-  COMPONENTS_LIBRARY_NAME=${COMPONENTS_LIBRARY_NAME:-rncore}
+-  MODULES_OUTPUT_DIR=${MODULES_OUTPUT_DIR:-"$RN_DIR/React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME"}
+-  # TODO: $COMPONENTS_PATH should be programmatically specified, and may change with use_frameworks! support.
+-  COMPONENTS_PATH="ReactCommon/react/renderer/components"
+-  COMPONENTS_OUTPUT_DIR=${COMPONENTS_OUTPUT_DIR:-"$RN_DIR/$COMPONENTS_PATH/$COMPONENTS_LIBRARY_NAME"}
+-
+-  TEMP_OUTPUT_DIR="$TEMP_DIR/out"
+-  SCHEMA_FILE="$TEMP_DIR/schema.json"
+-
+-  CODEGEN_REPO_PATH="$RN_DIR/packages/react-native-codegen"
+-  CODEGEN_NPM_PATH="$RN_DIR/../react-native-codegen"
+-
+-  if [ -z "$NODE_BINARY" ]; then
+-    echo "Error: Could not find node. Make sure it is in bash PATH or set the NODE_BINARY environment variable." 1>&2
+-    exit 1
+-  fi
+-
+-  if [ -d "$CODEGEN_REPO_PATH" ]; then
+-    CODEGEN_PATH=$(cd "$CODEGEN_REPO_PATH" && pwd)
+-  elif [ -d "$CODEGEN_NPM_PATH" ]; then
+-    CODEGEN_PATH=$(cd "$CODEGEN_NPM_PATH" && pwd)
+-  else
+-    echo "Error: Could not determine react-native-codegen location. Try running 'yarn install' or 'npm install' in your project root." 1>&2
+-    exit 1
+-  fi
+-
+-  if [ ! -d "$CODEGEN_PATH/lib" ]; then
+-    describe "Building react-native-codegen package"
+-    bash "$CODEGEN_PATH/scripts/oss/build.sh"
+-  fi
+-
+-  describe "Generating schema from flow types"
+-  "$NODE_BINARY" "$CODEGEN_PATH/lib/cli/combine/combine-js-to-schema-cli.js" "$SCHEMA_FILE" "$SRCS_DIR"
+-
+-  describe "Generating native code from schema (iOS)"
+-  pushd "$RN_DIR" >/dev/null || exit 1
+-    "$NODE_BINARY" scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$MODULES_LIBRARY_NAME"
+-  popd >/dev/null || exit 1
+-
+-  describe "Copying output to final directory"
+-  mkdir -p "$COMPONENTS_OUTPUT_DIR" "$MODULES_OUTPUT_DIR"
+-  cp -R "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME.h" "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME-generated.mm" "$MODULES_OUTPUT_DIR" || exit 1
+-  find "$TEMP_OUTPUT_DIR" -type f | xargs sed -i.bak "s/$MODULES_LIBRARY_NAME/$COMPONENTS_LIBRARY_NAME/g" || exit 1
+-  find "$TEMP_OUTPUT_DIR" -type f -not -iname "$MODULES_LIBRARY_NAME*" -exec cp '{}' "$COMPONENTS_OUTPUT_DIR/" ';' || exit 1
+-
+-  echo >&2 'Done.'
+-}
+-
+-trap cleanup EXIT
+-main "$@"
++# #!/bin/bash
++# # Copyright (c) Facebook, Inc. and its affiliates.
++# #
++# # This source code is licensed under the MIT license found in the
++# # LICENSE file in the root directory of this source tree.
++
++# # This script collects the JavaScript spec definitions for core
++# # native modules and components, then uses react-native-codegen
++# # to generate native code.
++# #
++# # Optionally, set these envvars to override defaults:
++# # - SRCS_DIR: Path to JavaScript sources
++# # - MODULES_LIBRARY_NAME: Defaults to FBReactNativeSpec
++# # - MODULES_OUTPUT_DIR: Defaults to React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME
++# # - COMPONENTS_LIBRARY_NAME: Defaults to rncore
++# # - COMPONENTS_OUTPUT_DIR: Defaults to ReactCommon/react/renderer/components/$COMPONENTS_LIBRARY_NAME
++# #
++# # Usage:
++# #   ./scripts/generate-specs.sh
++# #   SRCS_DIR=myapp/js MODULES_LIBRARY_NAME=MySpecs MODULES_OUTPUT_DIR=myapp/MySpecs ./scripts/generate-specs.sh
++# #
++
++# # shellcheck disable=SC2038
++
++# set -e
++
++# THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
++# TEMP_DIR=$(mktemp -d /tmp/react-native-codegen-XXXXXXXX)
++# RN_DIR=$(cd "$THIS_DIR/.." && pwd)
++# USE_FABRIC="${USE_FABRIC:-0}"
++
++# # Find path to Node
++# # shellcheck source=/dev/null
++# source "$RN_DIR/scripts/find-node.sh"
++
++# NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
++
++# cleanup () {
++#   set +e
++#   rm -rf "$TEMP_DIR"
++#   set -e
++# }
++
++# describe () {
++#   printf "\\n\\n>>>>> %s\\n\\n\\n" "$1"
++# }
++
++# main() {
++#   SRCS_DIR=${SRCS_DIR:-$(cd "$RN_DIR/Libraries" && pwd)}
++#   MODULES_LIBRARY_NAME=${MODULES_LIBRARY_NAME:-FBReactNativeSpec}
++
++#   COMPONENTS_LIBRARY_NAME=${COMPONENTS_LIBRARY_NAME:-rncore}
++#   MODULES_OUTPUT_DIR=${MODULES_OUTPUT_DIR:-"$RN_DIR/React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME"}
++#   # TODO: $COMPONENTS_PATH should be programmatically specified, and may change with use_frameworks! support.
++#   COMPONENTS_PATH="ReactCommon/react/renderer/components"
++#   COMPONENTS_OUTPUT_DIR=${COMPONENTS_OUTPUT_DIR:-"$RN_DIR/$COMPONENTS_PATH/$COMPONENTS_LIBRARY_NAME"}
++
++#   TEMP_OUTPUT_DIR="$TEMP_DIR/out"
++#   SCHEMA_FILE="$TEMP_DIR/schema.json"
++
++#   CODEGEN_REPO_PATH="$RN_DIR/packages/react-native-codegen"
++#   CODEGEN_NPM_PATH="$RN_DIR/../react-native-codegen"
++
++#   if [ -z "$NODE_BINARY" ]; then
++#     echo "Error: Could not find node. Make sure it is in bash PATH or set the NODE_BINARY environment variable." 1>&2
++#     exit 1
++#   fi
++
++#   if [ -d "$CODEGEN_REPO_PATH" ]; then
++#     CODEGEN_PATH=$(cd "$CODEGEN_REPO_PATH" && pwd)
++#   elif [ -d "$CODEGEN_NPM_PATH" ]; then
++#     CODEGEN_PATH=$(cd "$CODEGEN_NPM_PATH" && pwd)
++#   else
++#     echo "Error: Could not determine react-native-codegen location. Try running 'yarn install' or 'npm install' in your project root." 1>&2
++#     exit 1
++#   fi
++
++#   if [ ! -d "$CODEGEN_PATH/lib" ]; then
++#     describe "Building react-native-codegen package"
++#     bash "$CODEGEN_PATH/scripts/oss/build.sh"
++#   fi
++
++#   describe "Generating schema from flow types"
++#   "$NODE_BINARY" "$CODEGEN_PATH/lib/cli/combine/combine-js-to-schema-cli.js" "$SCHEMA_FILE" "$SRCS_DIR"
++
++#   describe "Generating native code from schema (iOS)"
++#   pushd "$RN_DIR" >/dev/null || exit 1
++#     "$NODE_BINARY" scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$MODULES_LIBRARY_NAME"
++#   popd >/dev/null || exit 1
++
++#   describe "Copying output to final directory"
++#   mkdir -p "$COMPONENTS_OUTPUT_DIR" "$MODULES_OUTPUT_DIR"
++#   cp -R "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME.h" "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME-generated.mm" "$MODULES_OUTPUT_DIR" || exit 1
++#   find "$TEMP_OUTPUT_DIR" -type f | xargs sed -i.bak "s/$MODULES_LIBRARY_NAME/$COMPONENTS_LIBRARY_NAME/g" || exit 1
++#   find "$TEMP_OUTPUT_DIR" -type f -not -iname "$MODULES_LIBRARY_NAME*" -exec cp '{}' "$COMPONENTS_OUTPUT_DIR/" ';' || exit 1
++
++#   echo >&2 'Done.'
++# }
++
++# trap cleanup EXIT
++# main "$@"


### PR DESCRIPTION
To support `Icon` in dooboo-ui, we need to use patch-packages to modifying minor things. Besides, `ios` build in react native v0.65 still has a problem. So we have to use patch-packages as we did [before](https://github.com/dooboolab/dooboo-native-ts/pull/170).